### PR TITLE
Feat: 뉴스데이터 사고 count 및 s3 저장 구현

### DIFF
--- a/extract/news/kbs_crawler.py
+++ b/extract/news/kbs_crawler.py
@@ -8,9 +8,6 @@ import requests
 import boto3
 from conf import BUCKET_NAME
 
-# Todo
-# parquet 저장
-
 class KBSCrawler :
     def __init__(self, request : NewsRequest) :
         self.request = request
@@ -90,7 +87,7 @@ class KBSCrawler :
             news_list.extend(news_data_list) 
             page_num += 1
 
-        f_name = f'data/news/{self.request["start_time"]}_{self.request["end_time"]}_KBS_{self.request["keyword"]}.parquet'
+        f_name = f'data/news/{self.request["start_time"]}_{self.request["end_time"]}/{self.request["keyword"]}_KBS.parquet'
         self.upload_s3(news_list, f_name)
 
         # 로컬용.

--- a/extract/news/kbs_crawler.py
+++ b/extract/news/kbs_crawler.py
@@ -7,6 +7,8 @@ import sys
 import requests
 import boto3
 from conf import BUCKET_NAME
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 class KBSCrawler :
     def __init__(self, request : NewsRequest) :
@@ -65,7 +67,11 @@ class KBSCrawler :
 
             # 데이터프레임을 parquet로 변환하여 메모리에서 처리
             parquet_buffer = io.BytesIO()
-            df.to_parquet(parquet_buffer, engine="pyarrow")
+
+            # Pyspark에서 datetime이 깨지기 때문에 us 단위로 변환하여 저장
+            table = pa.Table.from_pandas(df=df)
+            pq.write_table(table, parquet_buffer, coerce_timestamps='us')
+            # df.to_parquet(parquet_buffer, engine="pyarrow")
             parquet_buffer.seek(0)
 
             try:

--- a/extract/news/sbs_crawler.py
+++ b/extract/news/sbs_crawler.py
@@ -107,7 +107,7 @@ class SBSCrawler:
     
     def run(self):
         search_result = self.get_search_result()
-        f_name = f'data/news/{self.request["start_time"]}_{self.request["end_time"]}_SBS_{self.request["keyword"]}.parquet'
+        f_name = f'data/news/{self.request["start_time"]}_{self.request["end_time"]}/{self.request["keyword"]}_{self.NEWS_TAG}.parquet'
         self.upload_s3(search_result, f_name)
 
         # 로컬용

--- a/extract/news/sbs_crawler.py
+++ b/extract/news/sbs_crawler.py
@@ -3,6 +3,8 @@ import requests
 from bs4 import BeautifulSoup
 from datetime import datetime
 import sys
+import pyarrow as pa
+import pyarrow.parquet as pq
 from conf import BUCKET_NAME
 from type.news_crawler import NewsRequest, NewsResponse
 from typing import List, Optional
@@ -93,7 +95,11 @@ class SBSCrawler:
 
         # 데이터프레임을 parquet로 변환하여 메모리에서 처리
         parquet_buffer = io.BytesIO()
-        df.to_parquet(parquet_buffer, engine="pyarrow")
+
+        # Pyspark에서 datetime이 깨지기 때문에 us 단위로 변환하여 저장
+        table = pa.Table.from_pandas(df=df)
+        pq.write_table(table, parquet_buffer, coerce_timestamps='us')
+        # df.to_parquet(parquet_buffer, engine="pyarrow")
         parquet_buffer.seek(0)
 
         try:

--- a/transform/emr_transform_news.py
+++ b/transform/emr_transform_news.py
@@ -12,8 +12,7 @@ def transform(data_source:str, output_uri:str, batch_period:str)-> None:
                 .getOrCreate()as spark
     ):
         data_schema = StructType([
-            # TODO: post_time 타입 변경 필요
-            StructField('post_time', LongType(), True),
+            StructField('post_time', TimestampType(), True),
             StructField('title', StringType(), True),
             StructField('content', StringType(), True),
             StructField('source', StringType(), True),
@@ -29,6 +28,7 @@ def transform(data_source:str, output_uri:str, batch_period:str)-> None:
                 for accident in conf.ACCIDENT_KEYWORD
             ])
         )
+        df.show()
 
         df_exploded = df.withColumn("accident", F.explode(F.col("accident"))) \
             .filter(F.col("accident").isNotNull())
@@ -39,8 +39,8 @@ def transform(data_source:str, output_uri:str, batch_period:str)-> None:
         )
         res_df = res_df.withColumn("car", F.lit(df.select('keyword').first()[0]))
         res_df = res_df.select('car', 'accident', 'count', 'contents')
-        res_df.show()
-        res_df.coalesce(1).write.mode('overwrite').parquet(output_uri + batch_period + '/')
+        # res_df.show()
+        # res_df.coalesce(1).write.mode('overwrite').parquet(output_uri + batch_period + '/')
     return
 
 if __name__ == "__main__":

--- a/transform/emr_transform_news.py
+++ b/transform/emr_transform_news.py
@@ -1,0 +1,60 @@
+import argparse
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql.types import *
+import conf
+
+def transform(data_source:str, output_uri:str)-> None:
+    with (
+        SparkSession.builder.appName("EMR transform news")
+                .config("spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+                .config("spark.hadoop.fs.s3a.aws.credentials.provider", "com.amazonaws.auth.DefaultAWSCredentialsProviderChain")
+                .getOrCreate()as spark
+    ):
+        data_schema = StructType([
+            StructField('post_time', LongType(), True),
+            StructField('title', StringType(), True),
+            StructField('content', StringType(), True),
+            StructField('source', StringType(), True),
+            StructField('link', StringType(), True),
+            StructField('keyword', StringType(), True)
+        ])
+
+        df = spark.read.schema(data_schema).parquet(data_source)
+        df = df.withColumn(
+            'accident',
+            F.array(*[
+                F.when(F.col('title').contains(accident) | F.col('content').contains(accident), accident)
+                for accident in conf.ACCIDENT_KEYWORD
+            ])
+        )
+        # df.show()
+
+        df_exploded = df.withColumn("accident", F.explode(F.col("accident"))).filter(
+            F.col("accident").isNotNull()
+        )
+
+        res_df = df_exploded.groupBy("accident").agg(
+            F.count("*").alias("count"),
+            F.collect_list("content").alias("contents")
+        )
+        res_df = res_df.withColumn("car", F.lit(df.select('keyword').first()[0]))
+        res_df = res_df.select('car', 'accident', 'count', 'contents')
+        res_df.show()
+        # res_df.write.mode('overwrite').parquet(output_uri)
+    return
+
+if __name__ == "__main__":
+
+    # 로컬에서 사용 시 주석 해제
+    data_source = conf.S3_NEWS_DATA
+    output_uri = conf.S3_NEW_OUTPUT
+    transform(data_source, output_uri)
+
+    # EMR에서 실행할 때 주석 해제
+    # parser = argparse.ArgumentParser()
+    # parser.add_argument("--data_source", help="s3 uri")
+    # parser.add_argument("--output_uri", help="s3 uri")
+    # args = parser.parse_args()
+    #
+    # transform(args.data_source, args.output_uri)


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 뉴스 데이터 transform 과정 중 사고 마다 개수 카운트 까지 구현했습니다
- crwaler의 datetime을 ns단위에서 us단위로 저장하도록 수정했습니다
- emr코드가 s3에 저장하도록 구현했습니다
- 이제 파일들이 batch기간 이름의 폴더 하위에 저장됩니다
  - 뉴스 데이터의 경우 <키워드>_<언론사>.parquet 로 저장됩니다
### 🔍 참고 사항
- 참고해야 할 사항이 있다면 작성

### 🐞현재 버그
- 현재 버전에 버그가 있다면 작성

### #️⃣ 연관 이슈(Git Close)
- 이슈 넘버 작성(#)

### ❓논의 사항
- 논의 할 만한 내용 있으면 작성
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added an advanced news transformation capability that analyzes and aggregates news content based on key topics, improving insights into emerging trends.
	- Enhanced the transformation process to include a new parameter for batch period, allowing for more flexible data handling.
	- Introduced the `pyarrow` library for improved handling of Parquet file operations, enhancing data storage format and organization.
  
- **Bug Fixes**
	- Updated filename format for saving Parquet files to improve organization in the output directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->